### PR TITLE
Fix explicit nullable

### DIFF
--- a/src/database/src/AbstractConnection.php
+++ b/src/database/src/AbstractConnection.php
@@ -453,7 +453,7 @@ abstract class AbstractConnection implements ConnectionInterface
      * @param int $fetchStyle
      * @return array|object|false
      */
-    public function queryOne(int $fetchStyle = null)
+    public function queryOne(?int $fetchStyle = null)
     {
         $fetchStyle = $fetchStyle ?: $this->options[\PDO::ATTR_DEFAULT_FETCH_MODE];
         return $this->statement->fetch($fetchStyle);
@@ -464,7 +464,7 @@ abstract class AbstractConnection implements ConnectionInterface
      * @param int $fetchStyle
      * @return array
      */
-    public function queryAll(int $fetchStyle = null): array
+    public function queryAll(?int $fetchStyle = null): array
     {
         $fetchStyle = $fetchStyle ?: $this->options[\PDO::ATTR_DEFAULT_FETCH_MODE];
         return $this->statement->fetchAll($fetchStyle);

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -11,12 +11,12 @@ class Connection extends AbstractConnection
 
     protected $exceptional = false;
 
-    public function queryOne(int $fetchStyle = null)
+    public function queryOne(?int $fetchStyle = null)
     {
         return $this->call(__FUNCTION__, func_get_args());
     }
 
-    public function queryAll(int $fetchStyle = null): array
+    public function queryAll(?int $fetchStyle = null): array
     {
         return $this->call(__FUNCTION__, func_get_args());
     }


### PR DESCRIPTION
Fix #138 

Explicit nullable types were introduced in PHP 7.1, and the composer from this repo need PHP 7.3
https://github.com/mix-php/mix/blob/master/composer.json#L20
